### PR TITLE
Remove connectorId as default property

### DIFF
--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -32,7 +32,6 @@ dataset.createDataSet = function(options, cb)
 	if (options.columns == null) throw new Error("Cannot create a DataSet without a schema!");
 
 	var createRequest = {
-		connectorId: "com.domo.connector.workbench", // Defaulting to this
 		dataSourceType: createOptions.type,
 		dataSourceName: createOptions.name,
 		dataSourceDescription: createOptions.desc,


### PR DESCRIPTION
When creating data sources through the API in this manner, connectorId is an unneeded property and setting it to "com.domo.connector.workbench" might cause your data to be improperly categorized as a workbench DataSet.  You can either exclude it or set it to a unique wakizashi id.  It doesn't really matter in this case, as it is mostly ignored in this context.

BTW, since these are considered "internal" endpoints, they are obviously subject to breakage without warning.  Expect a more formalized public API at some point in the future.  That being said, it's exciting to see developers extending Domo to fit their needs.  Awesome.